### PR TITLE
build: Update bitcoinkernel to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoinkernel"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af4fd16f643d5bc585073c8513a9fde0a72278a38d0957b78cfd8f2c21bbb36"
+checksum = "202e7d3409ef1457abbe72404cfb3f43a104980313cc685e45cfe0366048618d"
 dependencies = [
  "libbitcoinkernel-sys",
 ]
@@ -435,7 +435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f8749105873c391b77fc943b7fdf8c05b6c1d06f6e71c6d2746ee7f8bda0072"
 dependencies = [
  "anyhow",
- "bitcoin_hashes 0.13.1",
+ "bitcoin_hashes 0.14.1",
  "bitreq 0.3.7",
  "corepc-client",
  "flate2",
@@ -812,9 +812,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbitcoinkernel-sys"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2906bc31f02dff7af9611fe9129c9eae021bd359f9d8e79824026fe1aaf28ab1"
+checksum = "ccee819dc48af6ce3fb213e6f93bae7a7231cd0689b0435afd86ab167cad5321"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.85.0"
 
 [dependencies]
 # bitcoinkernel = { path = "../rust-bitcoinkernel", version = "0.0.15" }
-bitcoinkernel = "0.2"
+bitcoinkernel = "0.3"
 addrman = { package = "bitcoin-address-book", version = "0.1.1" }
 bitcoin = { version = "0.32.8", features = ["rand-std"] }
 p2p = { package = "bitcoin-p2p", git =  "https://github.com/2140-dev/bitcoin-p2p.git", rev = "5dc03375636a10487c7e50659416876c28f58a3b" }

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 silentpayments = { version = "0.5", features = ["receiving", "encode", "sending"] }
 bitcoin = { version = "0.32.8", features = ["rand-std"] }
-bitcoinkernel = "0.2"
+bitcoinkernel = "0.3"
 log = "0.4"
 bdk_coin_select = "0.4.1"
 

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -16,8 +16,7 @@ use bitcoin::{
 };
 use bitcoin::{BlockHash, Network};
 use bitcoinkernel::{
-    core::BlockHashExt, prelude::BlockValidationStateExt, BlockTreeEntry, ChainstateManager,
-    Context, ProcessBlockHeaderResult, ValidationMode,
+    core::BlockHashExt, BlockTreeEntry, ChainstateManager, Context, ProcessBlockHeaderResult,
 };
 use log::{debug, info, warn};
 use p2p::{
@@ -177,9 +176,7 @@ pub fn process_message(
                 for header in headers.into_iter() {
                     let result = node_state.chainman.process_block_header(&header.convert());
                     match result {
-                        ProcessBlockHeaderResult::Success(state)
-                            if state.mode() == ValidationMode::Valid =>
-                        {
+                        Ok(ProcessBlockHeaderResult::Valid) => {
                             debug!(target: Category::KERNEL, "Processed header: {}", header.time);
                             continue;
                         }
@@ -216,7 +213,7 @@ pub fn process_message(
                     let block_hash = header.block_hash();
                     let valid = matches!(
                         node_state.chainman.process_block_header(&header.convert()),
-                        ProcessBlockHeaderResult::Success(s) if s.mode() == ValidationMode::Valid
+                        Ok(ProcessBlockHeaderResult::Valid)
                     );
                     if !valid {
                         warn!(target: Category::KERNEL, "Rejected announced header {}", block_hash);


### PR DESCRIPTION
process_block_header now returns a Result, and its success variant no longer carries a validation state, because the binding checks the mode itself. Match on Ok(ProcessBlockHeaderResult::Valid) and treat an error like a rejected header.