### PR TITLE
build: update silentpayments to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,12 +120,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
-name = "bimap"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
-
-[[package]]
 name = "bitcoin"
 version = "0.32.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,7 +429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f8749105873c391b77fc943b7fdf8c05b6c1d06f6e71c6d2746ee7f8bda0072"
 dependencies = [
  "anyhow",
- "bitcoin_hashes 0.13.1",
+ "bitcoin_hashes 0.14.1",
  "bitreq 0.3.7",
  "corepc-client",
  "flate2",
@@ -697,6 +691,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hex-conservative"
@@ -1205,12 +1202,11 @@ dependencies = [
 
 [[package]]
 name = "silentpayments"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131d42e3050dd88c79e4849b27eaf0cda0625f4e910d97bf05044a1300459f85"
+checksum = "beafae1833afa771481d8943492e5f1faf4f5582f9eca5db2ed6bce6ee05ef7e"
 dependencies = [
  "bech32 0.9.1",
- "bimap",
  "bitcoin_hashes 0.13.1",
  "hex",
  "secp256k1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ configure_me_codegen = "0.4.0"
 [dev-dependencies]
 tempfile = "3"
 corepc-node = { version = "0.12.0", default-features = false, features = ["30_2", "download"] }
-silentpayments = { version = "0.5", features = ["sending", "encode"] }
+silentpayments = { version = "0.7", features = ["sending", "encode"] }
 
 [package.metadata.configure_me]
 spec = "config_spec.toml"

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-silentpayments = { version = "0.5", features = ["receiving", "encode", "sending"] }
+silentpayments = { version = "0.7", features = ["receiving", "encode", "sending"] }
 bitcoin = { version = "0.32.8", features = ["rand-std"] }
 bitcoinkernel = "0.2"
 log = "0.4"

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -4,7 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-silentpayments = { version = "0.7", features = ["receiving", "encode", "sending"] }
+silentpayments = { version = "0.7", features = [
+  "receiving",
+  "encode",
+  "sending",
+] }
 bitcoin = { version = "0.32.8", features = ["rand-std"] }
 bitcoinkernel = "0.2"
 log = "0.4"

--- a/crates/wallet/src/silentpayments/mod.rs
+++ b/crates/wallet/src/silentpayments/mod.rs
@@ -5,10 +5,11 @@ mod wallet;
 mod wallet_store;
 
 pub use ::silentpayments::receiving::{Label, Receiver};
-pub use ::silentpayments::{Network, SilentPaymentAddress};
+pub use ::silentpayments::{Network, SilentPaymentCode};
 pub use keys_file::{SilentPaymentKeysFile, SpendKey};
 pub use scanning::{scan_transaction, InputData};
 pub use sending::{Recipient, SendError};
+use silentpayments::SpVersion;
 pub use wallet::{Coin, HistoryEntry, SilentPaymentKeys, SpentBy, Wallet};
 pub use wallet_store::{WalletPersistenceError, WalletStore, WalletStoreError};
 
@@ -22,5 +23,11 @@ pub fn build_receiver(
     let secp = secp256k1::Secp256k1::signing_only();
     let scan_pubkey = PublicKey::from_secret_key(&secp, b_scan);
     let change_label = Label::new(*b_scan, 0);
-    Receiver::new(0, scan_pubkey, b_spend_pub, change_label, network)
+    Receiver::new(
+        SpVersion::ZERO,
+        scan_pubkey,
+        b_spend_pub,
+        change_label,
+        network,
+    )
 }

--- a/crates/wallet/src/silentpayments/scanning.rs
+++ b/crates/wallet/src/silentpayments/scanning.rs
@@ -2,8 +2,8 @@ use ::silentpayments::{
     receiving::{Label, Receiver},
     utils::receiving::{calculate_ecdh_shared_secret, calculate_tweak_data, get_pubkey_from_input},
 };
-use bitcoin::consensus::encode;
 use bitcoin::secp256k1::{self, Scalar, SecretKey, XOnlyPublicKey};
+use bitcoin::{consensus::encode, hashes::Hash};
 use bitcoin::{OutPoint, Script, Transaction};
 use bitcoinkernel::prelude::{
     BlockSpentOutputsExt, CoinExt, ScriptPubkeyExt, TransactionExt, TransactionSpentOutputsExt,
@@ -16,8 +16,7 @@ pub struct InputData {
     pub script_sig: Vec<u8>,
     pub witness: Vec<Vec<u8>>,
     pub prevout_script: Vec<u8>,
-    pub txid: String,
-    pub vout: u32,
+    pub outpoint: silentpayments::utils::OutPoint,
 }
 
 pub fn scan_transaction(
@@ -33,7 +32,7 @@ pub fn scan_transaction(
             get_pubkey_from_input(&input.script_sig, &input.witness, &input.prevout_script)
         {
             input_pub_keys.push(pk);
-            outpoints.push((input.txid.clone(), input.vout));
+            outpoints.push(input.outpoint);
         }
     }
 
@@ -69,7 +68,7 @@ pub fn scan_transaction(
     let shared_secret = calculate_ecdh_shared_secret(&tweak_data, b_scan);
 
     let xonly_outputs: Vec<XOnlyPublicKey> = taproot_outputs.iter().map(|(_, pk)| *pk).collect();
-    let found = match receiver.scan_transaction(&shared_secret, xonly_outputs) {
+    let found = match receiver.scan_transaction(&shared_secret, &xonly_outputs) {
         Ok(f) => f,
         Err(_) => return vec![],
     };
@@ -119,12 +118,14 @@ pub(crate) fn scan_block_inner(
             let coin = tx_spent
                 .coin(input_idx)
                 .expect("input/spent-output count mismatch");
+            let mut buf = [0u8; 36];
+            buf[..32].copy_from_slice(&btc_input.previous_output.txid.to_byte_array());
+            buf[32..].copy_from_slice(&btc_input.previous_output.vout.to_le_bytes());
             inputs.push(InputData {
                 script_sig: btc_input.script_sig.as_bytes().to_vec(),
                 witness: btc_input.witness.iter().map(|item| item.to_vec()).collect(),
                 prevout_script: coin.output().script_pubkey().to_bytes(),
-                txid: btc_input.previous_output.txid.to_string(),
-                vout: btc_input.previous_output.vout,
+                outpoint: silentpayments::utils::OutPoint::from_bytes(buf),
             });
         }
 

--- a/crates/wallet/src/silentpayments/sending.rs
+++ b/crates/wallet/src/silentpayments/sending.rs
@@ -18,7 +18,7 @@ use bitcoin::{
 };
 use silentpayments::sending::generate_recipient_pubkeys;
 use silentpayments::utils::sending::calculate_partial_secret;
-use silentpayments::{Network, SilentPaymentAddress};
+use silentpayments::{Network, SilentPaymentCode, SilentPaymentKeyMaterial};
 
 use crate::silentpayments::wallet::{Coin, Wallet};
 
@@ -102,14 +102,14 @@ impl From<bitcoin::sighash::TaprootError> for SendError {
 }
 
 pub enum Recipient {
-    SilentPayment(SilentPaymentAddress),
+    SilentPayment(SilentPaymentCode),
     Address(Address),
 }
 
 impl Recipient {
     pub fn parse(s: &str, network: Network) -> Result<Self, SendError> {
-        if let Ok(sp) = SilentPaymentAddress::try_from(s) {
-            if sp.get_network() != network {
+        if let Ok(sp) = SilentPaymentCode::try_from(s) {
+            if sp.network() != network {
                 return Err(SendError::NetworkMismatch);
             }
             return Ok(Recipient::SilentPayment(sp));
@@ -145,7 +145,7 @@ impl Wallet {
     ) -> Result<Transaction, SendError> {
         let spend_secret = self.spend_secret.ok_or(SendError::WatchOnly)?;
         let keys = self.keys.as_ref().ok_or(SendError::WatchOnly)?;
-        let change_address = keys.receiver.get_change_address();
+        let change_address = keys.receiver.change_code();
 
         let coins: Vec<SpendableCoin> = self
             .utxos
@@ -178,7 +178,7 @@ fn build_transaction(
     fee_rate: FeeRate,
     long_term_fee_rate: FeeRate,
     tip_height: u32,
-    change_address: SilentPaymentAddress,
+    change_address: SilentPaymentCode,
     coins: &[SpendableCoin],
 ) -> Result<Transaction, SendError> {
     if coins.is_empty() {
@@ -230,22 +230,27 @@ fn build_transaction(
 
     let change_value = drain.is_some().then(|| Amount::from_sat(drain.value));
     let recipient_is_sp = matches!(recipient, Recipient::SilentPayment(_));
-    let derived: HashMap<SilentPaymentAddress, Vec<XOnlyPublicKey>> = if recipient_is_sp
+    let derived: HashMap<SilentPaymentKeyMaterial, Vec<XOnlyPublicKey>> = if recipient_is_sp
         || change_value.is_some()
     {
         // true marks each key as taproot since every silent payment coin is a P2TR output
         let input_keys: Vec<(SecretKey, bool)> = signing_keys.iter().map(|k| (*k, true)).collect();
-        let outpoints: Vec<(String, u32)> = selected
+        let outpoints: Vec<silentpayments::utils::OutPoint> = selected
             .iter()
-            .map(|c| (c.outpoint.txid.to_string(), c.outpoint.vout))
+            .map(|c| {
+                let mut buf = [0u8; 36];
+                buf[..32].copy_from_slice(&c.outpoint.txid.to_byte_array());
+                buf[32..].copy_from_slice(&c.outpoint.vout.to_le_bytes());
+                silentpayments::utils::OutPoint::from_bytes(buf)
+            })
             .collect();
         let partial_secret = calculate_partial_secret(&input_keys, &outpoints)?;
-        let mut sp_addrs = Vec::new();
+        let mut sp_addrs: Vec<SilentPaymentKeyMaterial> = Vec::new();
         if let Recipient::SilentPayment(sp) = &recipient {
-            sp_addrs.push(*sp);
+            sp_addrs.push(sp.into());
         }
         if change_value.is_some() {
-            sp_addrs.push(change_address);
+            sp_addrs.push(change_address.into());
         }
         generate_recipient_pubkeys(sp_addrs, partial_secret)?
     } else {
@@ -366,11 +371,11 @@ fn output_weight(script_len: usize) -> Weight {
 }
 
 fn sp_output_script(
-    derived: &HashMap<SilentPaymentAddress, Vec<XOnlyPublicKey>>,
-    address: SilentPaymentAddress,
+    derived: &HashMap<SilentPaymentKeyMaterial, Vec<XOnlyPublicKey>>,
+    address: SilentPaymentCode,
 ) -> Result<ScriptBuf, SendError> {
     let xonly = derived
-        .get(&address)
+        .get(&address.into())
         .and_then(|keys| keys.first())
         .ok_or(SendError::OutputDerivation)?;
     Ok(p2tr_script(*xonly))
@@ -403,12 +408,12 @@ mod tests {
         }
     }
 
-    fn address(scan: SecretKey, spend: SecretKey) -> SilentPaymentAddress {
+    fn address(scan: SecretKey, spend: SecretKey) -> SilentPaymentCode {
         let secp = Secp256k1::new();
         let spend_pub = spend.public_key(&secp);
         build_receiver(&scan, spend_pub, Network::Regtest)
             .unwrap()
-            .get_receiving_address()
+            .receiving_code()
     }
 
     fn owned_coin(spend_secret: &SecretKey, tweak: Scalar, value: Amount) -> Coin {
@@ -439,7 +444,7 @@ mod tests {
             Network::Regtest,
         )
         .unwrap()
-        .get_change_address();
+        .change_code();
 
         let recipient = address(even_secret([0x03; 32]), even_secret([0x04; 32]));
 
@@ -678,7 +683,7 @@ mod tests {
             Network::Regtest,
         )
         .unwrap()
-        .get_change_address();
+        .change_code();
         let recipient = address(even_secret([0x03; 32]), even_secret([0x04; 32]));
 
         let owned: Vec<Coin> = [55_000u64, 30_000, 20_000]

--- a/crates/wallet/src/silentpayments/wallet.rs
+++ b/crates/wallet/src/silentpayments/wallet.rs
@@ -225,7 +225,7 @@ impl Wallet {
     pub fn receive_address(&self) -> Option<String> {
         self.keys
             .as_ref()
-            .map(|k| k.receiver.get_receiving_address().to_string())
+            .map(|k| k.receiver.receiving_code().to_string())
     }
 
     pub fn balance(&self) -> Amount {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -15,7 +15,7 @@ use corepc_node::{Conf, Node, P2P};
 use kernel_node::server_capnp::server;
 use silentpayments::sending::generate_recipient_pubkeys;
 use silentpayments::utils::sending::calculate_partial_secret;
-use silentpayments::SilentPaymentAddress;
+use silentpayments::SilentPaymentCode;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use wallet::io::FileExt;
 use wallet::silentpayments::{SilentPaymentKeysFile, SpendKey};
@@ -312,15 +312,18 @@ pub fn fund_silent_payment(core: &Node, sp_address: &str, amount: Amount) {
     };
     let prev_txout = coinbase.output[0].clone();
 
-    let sp = SilentPaymentAddress::try_from(sp_address).unwrap();
+    let sp = SilentPaymentCode::try_from(sp_address).unwrap();
+    let mut buf = [0u8; 36];
+    buf[..32].copy_from_slice(&prevout.txid.to_byte_array());
+    buf[32..].copy_from_slice(&prevout.vout.to_le_bytes());
     let partial_secret = calculate_partial_secret(
         &[(sender_sk, false)],
-        &[(prevout.txid.to_string(), prevout.vout)],
+        &[silentpayments::utils::OutPoint::from_bytes(buf)],
     )
     .unwrap();
-    let derived = generate_recipient_pubkeys(vec![sp], partial_secret).unwrap();
+    let derived = generate_recipient_pubkeys(vec![sp.into()], partial_secret).unwrap();
     let output_key = derived
-        .get(&sp)
+        .get(&sp.into())
         .and_then(|keys| keys.first())
         .copied()
         .unwrap();

--- a/tests/wallet_import.rs
+++ b/tests/wallet_import.rs
@@ -3,7 +3,7 @@ mod common;
 use bitcoin::hex::DisplayHex;
 use bitcoin::secp256k1::{Secp256k1, SecretKey};
 use common::TestNode;
-use silentpayments::SilentPaymentAddress;
+use silentpayments::SilentPaymentCode;
 
 #[test]
 fn imports_keys_over_the_cli() {
@@ -22,7 +22,7 @@ fn imports_keys_over_the_cli() {
     node.import_keys(&scan_hex, &spend_pub_hex);
 
     let address = node.receive_address();
-    SilentPaymentAddress::try_from(address.as_str())
+    SilentPaymentCode::try_from(address.as_str())
         .expect("import should yield a valid silent payment address");
 
     node.stop();


### PR DESCRIPTION
Updates the silentpayments dependency from 0.5.0 to 0.7.0 (latest), introducing a few api changes:

1. functions that take an OutPoint as an argument now take a custom OutPoint struct instead of a (String, u32) pair.
2. renamed some getters, dropped the 'get_' prefix.
3. SilentPaymentAddress has been split into 2 separate structs, SilentPaymentCode and SilentPaymentKeyMaterial. The former represents a bech32-encoded address. The latter is the key material used to actually perform the calculations. This split was useful for PSBT's which provide only the key material, but not network info.